### PR TITLE
Arguments in transplant_barrels.nrrd

### DIFF
--- a/barrel-annotations/transplant_barrels_nrrd_script.py
+++ b/barrel-annotations/transplant_barrels_nrrd_script.py
@@ -2,10 +2,18 @@ import argparse
 import numpy as np
 from voxcell import VoxelData
 
-def transplant_annotations(data_path, resolution):
+def transplant_annotations(data_path, annotation_path, resolution):
+    """
+    Transplant pregenerated barrel annotations into an annotation file.
+    :param data_path:
+    :param annotation_path:
+    :param resolution:
+    :return:
+    """
+    print('Transplanting barrel annotations into annotation file...')
     # Define paths based on provided data_path and resolution
     annotation_barrels_path = f"{data_path}/annotation_barrels.nrrd"
-    annotation_path = f"{data_path}/annotation_{resolution}.nrrd"
+    annotation_path = f"{annotation_path}/annotation_{resolution}.nrrd"
     output_path = f"{data_path}/annotation_barrels_{resolution}.nrrd"
 
     # Load the necessary nrrd files
@@ -35,12 +43,14 @@ def transplant_annotations(data_path, resolution):
     )
 
     # Save the updated annotation data to the output path
+    print('Saving updated annotation data to output path...')
     barrel_nrrd.save_nrrd(output_path)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Transplant pregenerated barrel annotations into an annotation file.')
-    parser.add_argument('data_path', type=str, help='Base path to the data files')
+    parser.add_argument('data_path', type=str, help='Path to new data files')
+    parser.add_argument('annotation_path', type=str, help='Path to the original Allen annotation file')
     parser.add_argument('resolution', type=str, help='Resolution identifier to determine which annotation file to use')
 
     args = parser.parse_args()
-    transplant_annotations(args.data_path, args.resolution)
+    transplant_annotations(args.data_path, args.annotation_path, args.resolution)

--- a/barrel-annotations/transplant_barrels_nrrd_script.py
+++ b/barrel-annotations/transplant_barrels_nrrd_script.py
@@ -1,0 +1,46 @@
+import argparse
+import numpy as np
+from voxcell import VoxelData
+
+def transplant_annotations(data_path, resolution):
+    # Define paths based on provided data_path and resolution
+    annotation_barrels_path = f"{data_path}/annotation_barrels.nrrd"
+    annotation_path = f"{data_path}/annotation_{resolution}.nrrd"
+    output_path = f"{data_path}/annotation_barrels_{resolution}.nrrd"
+
+    # Load the necessary nrrd files
+    barrel = VoxelData.load_nrrd(annotation_barrels_path)
+    annotation = VoxelData.load_nrrd(annotation_path)
+
+    # Extract the raw data from the annotation files
+    annotation_raw = annotation.raw
+    barrel_raw = barrel.raw
+
+    # Identify the indices where barrel annotation is present
+    indices = np.argwhere(barrel_raw > 0)
+
+    # Create a mask of the same shape as the annotation file
+    mask = np.zeros(annotation.shape, dtype=bool)
+
+    # Set the mask to True where the barrel indices are present
+    for indx in indices:
+        mask[tuple(indx)] = True
+
+    # Update the annotation data where the mask is True
+    annotation_raw[mask] = barrel_raw[mask]
+
+    # Create a new VoxelData object for the output
+    barrel_nrrd = VoxelData(
+        annotation_raw, annotation.voxel_dimensions, offset=annotation.offset
+    )
+
+    # Save the updated annotation data to the output path
+    barrel_nrrd.save_nrrd(output_path)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Transplant pregenerated barrel annotations into an annotation file.')
+    parser.add_argument('data_path', type=str, help='Base path to the data files')
+    parser.add_argument('resolution', type=str, help='Resolution identifier to determine which annotation file to use')
+
+    args = parser.parse_args()
+    transplant_annotations(args.data_path, args.resolution)


### PR DESCRIPTION
Hello,

I am using a library (BrainGlobe) that uses the Allen atlas for analysis of my own data (Neuropixels track localization). 
The library has an API for atlas objets (https://brainglobe.info/documentation/brainglobe-atlasapi/adding-a-new-atlas.html#what-data-do-you-need-to-contribute-an-atlas-to-the-brainglobe-initiative) and I am planning to add an new atlas object that consists of the Allen atlas but with barrel annotations. I have already discussed the task with @alTeska recently and provided me intermediate annotation_barrels .nrrd files to make the new atlas objects.

But in order to programatically generate these atlases within the BrainGlobe library, I'd require the script `transplant_barrels_nrrd.py` to accept arguments, in particular to generate the new annotation file with 10 or 25 microns resolution. More precisely, the atlas generation script in the BrainGlobe library will call this script to generate the annotation files.
The reason we do this is because these annotation files are not readily available online. We think it's better to use the current code to generate them upon generating the BrainGlobe atlas object.


This PR adds `transplant_barrels_nrrd_script.py` which modifies the current file but with arguments, in particular the resolution.

Let me know if you have any questions, or if you think things could be changed.

Best,
Axel
(LSENS, EPFL)
